### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ forge init -t drosera-network/trap-foundry-template
 **Compile Trap**:
 ```bash
 curl -fsSL https://bun.sh/install | bash
+
+source ~/.bashrc
+
 bun install
 ```
 ```bash


### PR DESCRIPTION
After running the official Bun installation script (curl -fsSL https://bun.sh/install | bash), the script adds ~/.bun/bin to the PATH via .bashrc. However, the bun command is not available until the user manually runs source ~/.bashrc or restarts the shell session.