### PR TITLE
Ravnica44 patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo docker run hello-world
 curl -L https://app.drosera.io/install | bash
 ```
 ```
-source /root/.bashrc
+echo 'export PATH="$HOME/drosera/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 ```
 ```
 droseraup
@@ -62,7 +62,7 @@ droseraup
 curl -L https://foundry.paradigm.xyz | bash
 ```
 ```
-source /root/.bashrc
+echo 'export PATH="$HOME/.foundry/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 ```
 ```
 foundryup
@@ -205,13 +205,14 @@ tar -xvf drosera-operator-v1.17.2-x86_64-unknown-linux-gnu.tar.gz
 * Currently the Operator CLI version is `v1.17.2`. Verify the latest version [here](https://github.com/drosera-network/releases/releases)
 * You have to get the link of `drosera-operator-v1.x.x-x86_64-unknown-linux-gnu.tar.gz`
 
+# Move path to run it globally
+`mv drosera-operator ~/drosera/bin/`
+`echo 'export PATH="$HOME/drosera/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc`
+
 Test the CLI with `./drosera-operator --version` to verify it's working.
 ```console
 # Check version
 ./drosera-operator --version
-
-# Move path to run it globally
-sudo cp drosera-operator /usr/bin
 
 # Check if it is working
 drosera-operator

--- a/README.md
+++ b/README.md
@@ -206,9 +206,10 @@ tar -xvf drosera-operator-v1.17.2-x86_64-unknown-linux-gnu.tar.gz
 * You have to get the link of `drosera-operator-v1.x.x-x86_64-unknown-linux-gnu.tar.gz`
 
 # Move path to run it globally
-`mv drosera-operator ~/drosera/bin/`
-`echo 'export PATH="$HOME/drosera/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc`
-
+```bash
+mv drosera-operator ~/drosera/bin/
+echo 'export PATH="$HOME/drosera/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
+```
 Test the CLI with `./drosera-operator --version` to verify it's working.
 ```console
 # Check version

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ tar -xvf drosera-operator-v1.17.2-x86_64-unknown-linux-gnu.tar.gz
 * Currently the Operator CLI version is `v1.17.2`. Verify the latest version [here](https://github.com/drosera-network/releases/releases)
 * You have to get the link of `drosera-operator-v1.x.x-x86_64-unknown-linux-gnu.tar.gz`
 
-# Move path to run it globally
+## Move path to run it globally
 ```bash
 mv drosera-operator ~/drosera/bin/
 echo 'export PATH="$HOME/drosera/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,38 @@
 version: '3'
+
 services:
   drosera:
     image: ghcr.io/drosera-network/drosera-operator:latest
     container_name: drosera-node
+
     ports:
       - "31313:31313"
       - "31314:31314"
+
     volumes:
       - drosera_data:/data
-    command: node --db-file-path /data/drosera.db --network-p2p-port 31313 --server-port 31314 --eth-rpc-url https://ethereum-holesky-rpc.publicnode.com --eth-backup-rpc-url https://holesky.drpc.org --drosera-address 0xea08f7d533C2b9A62F40D5326214f39a8E3A32F8 --eth-private-key ${ETH_PRIVATE_KEY} --listen-address 0.0.0.0 --network-external-p2p-address ${VPS_IP} --disable-dnr-confirmation true
+
+    command: >
+      node
+      --db-file-path /data/drosera.db
+      --network-p2p-port 31313
+      --server-port 31314
+      --eth-rpc-url https://ethereum-holesky-rpc.publicnode.com
+      --eth-backup-rpc-url https://holesky.drpc.org
+      --drosera-address 0xea08f7d533C2b9A62F40D5326214f39a8E3A32F8
+      --eth-private-key ${ETH_PRIVATE_KEY}
+      --listen-address 0.0.0.0
+      --network-external-p2p-address ${VPS_IP}
+      --disable-dnr-confirmation true
+
     restart: always
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"    # Maximum size of a log file before rotation
+        max-file: "3"      # Maximum number of log files to keep
 
 volumes:
   drosera_data:
+  

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "10m"    # Maximum size of a log file before rotation
+        max-size: "100m"   # Maximum size of a log file before rotation
         max-file: "3"      # Maximum number of log files to keep
 
 volumes:


### PR DESCRIPTION
This update introduces log rotation settings to the Drosera service in the Docker Compose file. Specifically, it limits the maximum log file size to 10 megabytes and retains up to 3 log files. This helps prevent excessive disk space usage from unbounded log growth and improves overall container log management.

And optimizations of various Bash shell commands.
